### PR TITLE
auto bind 16n

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ Controls:
 * [K3] + [E3] change FM index
 * [K1] + [E2] - change sample rate
 * [K1] + [E3] - change bit depth
-* [K2] + [K3] toggle voice pannning between 'middle' and odd numbered voices hard left, even numbered voices hard right. 
+* [K2] + [K3] toggle voice pannning between 'middle' and odd numbered voices hard left, even numbered voices hard right.
+
+When a 16n is detected, each of its sliders gets automatically assigned to a sine.
+
+16n controls:
+
+* (no modifier key) sine amplitude
+* [K2] detune
+* [K3] FM index
+* [K1] + [K2] sample rate
+* [K1] + [K3] bit depth
+* [K1] + [K2] + [K3] change note
 
 Saving a pset saves the note selection and midi mapping. The last saved pset is loaded when the app launches.
 

--- a/lib/16n.lua
+++ b/lib/16n.lua
@@ -1,0 +1,170 @@
+
+local _16n = {}
+
+
+-- ------------------------------------------------------------------------
+-- SYSEX
+
+-- 0x1F - "1nFo"
+_16n.request_sysex_config_dump = function(midi_dev)
+  midi.send(midi_dev, {0xf0, 0x7d, 0x00, 0x00, 0x1f, 0xf7})
+end
+
+-- 0x0F - "c0nFig"
+_16n.is_sysex_config_dump = function(sysex_payload)
+  return (sysex_payload[2] == 0x7d and sysex_payload[3] == 0x00 and sysex_payload[4] == 0x00
+          and sysex_payload[5] == 0x0f)
+end
+
+_16n.parse_sysex_config_dump = function(sysex_payload)
+  local i = 6 + 4 -- offset
+  local led_power_on = false
+  local led_data_blink = false
+  local rot = false
+  local min_v = 0
+  local max_v = 127
+  local raw_min_v = 0
+  local raw_max_v = 0
+  local usb_ch_list={}
+  local trs_ch_list={}
+  local usb_cc_list={}
+  local trs_cc_list={}
+
+  if sysex_payload[i+0] == 1 then
+    led_power_on = true
+  end
+  if sysex_payload[i+1] == 1 then
+    led_data_blink = true
+  end
+  if sysex_payload[i+2] == 1 then
+    rot = true
+  end
+  if sysex_payload[i+2] == 1 then
+    rot = true
+  end
+
+  -- NB: these seem to be wrongly reported...
+  raw_min_v = (sysex_payload[i+5] << 8) + sysex_payload[i+4]
+  raw_max_v = (sysex_payload[i+7] << 8) + sysex_payload[i+6]
+
+  for fader_i=0, 16-1 do
+    local usb_ch = sysex_payload[i+16+fader_i]
+    table.insert(usb_ch_list, usb_ch)
+
+    local trs_ch = sysex_payload[i+32+fader_i]
+    table.insert(usb_ch_list, trs_ch)
+
+    local trs_cc = sysex_payload[i+48+fader_i]
+    table.insert(usb_cc_list, trs_cc)
+
+    local usb_cc = sysex_payload[i+64+fader_i]
+    table.insert(trs_cc_list, usb_cc)
+  end
+
+  return {
+    led_power_on = led_power_on,
+    led_data_blink = led_data_blink,
+    rot = rot,
+    min_v = min_v,
+    max_v = max_v,
+    raw_min_v = raw_min_v,
+    raw_max_v = raw_max_v,
+    usb_ch = usb_ch_list,
+    trs_ch = trs_ch_list,
+    usb_cc = usb_cc_list,
+    trs_cc = trs_cc_list,
+  }
+end
+
+
+-- ------------------------------------------------------------------------
+-- PLUG'N'PLAY MIDI BINDING
+
+local dev_16n=nil
+local midi_16n=nil
+local conf_16n=nil
+
+
+_16n.init = function(cc_cb_fn)
+  for _,dev in pairs(midi.devices) do
+    if dev.name~=nil and dev.name == "16n" then
+      print("detected 16n, will lookup its confif via sysex")
+
+      dev_16n = dev
+      midi_16n = midi.connect(dev.port)
+
+      local is_sysex_dump_on = false
+      local sysex_payload = {}
+
+      midi_16n.event=function(data)
+        local d=midi.to_msg(data)
+
+        if is_sysex_dump_on then
+          for _, b in pairs(data) do
+            table.insert(sysex_payload, b)
+            if b == 0xf7 then
+              is_sysex_dump_on = false
+              if _16n.is_sysex_config_dump(sysex_payload) then
+                conf_16n = _16n.parse_sysex_config_dump(sysex_payload)
+                print("done retrieving 16n config")
+              end
+            end
+          end
+        elseif d.type == 'sysex' then
+          is_sysex_dump_on = true
+          sysex_payload = {}
+          for _, b in pairs(d.raw) do
+            table.insert(sysex_payload, b)
+          end
+        elseif d.type == 'cc' and conf_16n ~= nil then
+          if cc_cb_fn ~= nil then
+            cc_cb_fn(d)
+          end
+        end
+      end
+
+      -- ask config dump via sysex
+      _16n.request_sysex_config_dump(dev_16n)
+
+      break
+    end
+  end
+end
+
+
+-- ------------------------------------------------------------------------
+-- CONF ACCESSORS (STATEFUL)
+
+local function mustHaveConf()
+  if conf_16n == nil then
+    error("Attempted to access 16n configuration while the later didn't get retrieved.")
+  end
+end
+
+_16n.cc_2_slider_id = function(cc)
+  mustHaveConf()
+
+  local slider_id = nil
+  for i, slider_cc in pairs(conf_16n.usb_cc) do
+    if slider_cc == cc then
+      slider_id = i
+    end
+  end
+
+  return slider_id
+end
+
+_16n.min_v = function()
+  mustHaveConf()
+  return conf_16n.min_v
+end
+
+_16n.max_v = function()
+  mustHaveConf()
+  return conf_16n.max_v
+end
+
+
+-- ------------------------------------------------------------------------
+
+return _16n

--- a/sines.lua
+++ b/sines.lua
@@ -61,10 +61,10 @@ function init()
 		sliders[i] = (params:get("vol" .. i))*32
 	end
 
-        _16n.init(init_16n)
+        _16n.init(16n_slider_callback)
 end
 
-function init_16n(midi_msg)
+function 16n_slider_callback(midi_msg)
   local slider_id = _16n.cc_2_slider_id(midi_msg.cc)
   local v = midi_msg.val
 

--- a/sines.lua
+++ b/sines.lua
@@ -61,10 +61,10 @@ function init()
 		sliders[i] = (params:get("vol" .. i))*32
 	end
 
-        _16n.init(16n_slider_callback)
+        _16n.init(_16n_slider_callback)
 end
 
-function 16n_slider_callback(midi_msg)
+function _16n_slider_callback(midi_msg)
   local slider_id = _16n.cc_2_slider_id(midi_msg.cc)
   local v = midi_msg.val
 

--- a/sines.lua
+++ b/sines.lua
@@ -64,6 +64,26 @@ function init()
         _16n.init(_16n_slider_callback)
 end
 
+local prev_16n_slider_v = {
+  vol= {},
+  cents= {},
+  fm_index= {},
+  smpl_rate= {},
+  bit_depth= {},
+  node= {},
+}
+
+function is_prev_16n_slider_v_crossing(mode, i, v)
+  local prev_v = prev_16n_slider_v[mode][i]
+  if prev_v == nil then
+    return true
+  end
+  if math.abs(v - prev_v) < 10 then
+    return true
+  end
+  return false
+end
+
 function _16n_slider_callback(midi_msg)
   local slider_id = _16n.cc_2_slider_id(midi_msg.cc)
   local v = midi_msg.val
@@ -77,18 +97,36 @@ function _16n_slider_callback(midi_msg)
   edit = accum
 
   if key_1_pressed == 0 and key_3_pressed == 0 and key_2_pressed == 0 then
-    params:set("vol" .. edit+1, util.linlin(0, 127, 0.0, 1.0, v))
-    sliders[edit+1] = util.linlin(0, 127, 0, 32, v)
+    if is_prev_16n_slider_v_crossing("vol", slider_id, v) then
+      params:set("vol" .. edit+1, util.linlin(0, 127, 0.0, 1.0, v))
+      sliders[edit+1] = util.linlin(0, 127, 0, 32, v)
+      prev_16n_slider_v["vol"][slider_id] = v
+    end
   elseif key_1_pressed == 0 and key_2_pressed == 1 and key_3_pressed == 0 then
-    params:set("cents" .. edit+1, util.linlin(0, 127, -200, 200, v))
+    if is_prev_16n_slider_v_crossing("cents", slider_id, v) then
+      params:set("cents" .. edit+1, util.linlin(0, 127, -200, 200, v))
+      prev_16n_slider_v["cents"][slider_id] = v
+    end
   elseif key_1_pressed == 0 and key_2_pressed == 0 and key_3_pressed == 1 then
-    params:set("fm_index" .. edit+1, util.linlin(0, 127, 0.0, 200.0, v))
+    if is_prev_16n_slider_v_crossing("fm_index", slider_id, v) then
+      params:set("fm_index" .. edit+1, util.linlin(0, 127, 0.0, 200.0, v))
+      prev_16n_slider_v["fm_index"][slider_id] = v
+    end
   elseif key_1_pressed == 1  and key_2_pressed == 1 and key_3_pressed == 0 then
-    params:set("smpl_rate" .. edit+1, util.linlin(0, 127, 480, 48000, v))
+    if is_prev_16n_slider_v_crossing("smpl_rate", slider_id, v) then
+      params:set("smpl_rate" .. edit+1, util.linlin(0, 127, 480, 48000, v))
+      prev_16n_slider_v["smpl_rate"][slider_id] = v
+    end
   elseif key_1_pressed == 1  and key_2_pressed == 0 and key_3_pressed == 1 then
-    params:set("bit_depth" .. edit+1, util.linlin(0, 127, 1, 24, v))
+    if is_prev_16n_slider_v_crossing("bit_depth", slider_id, v) then
+      params:set("bit_depth" .. edit+1, util.linlin(0, 127, 1, 24, v))
+      prev_16n_slider_v["bit_depth"][slider_id] = v
+    end
   elseif key_1_pressed == 1  and key_2_pressed == 1 and key_3_pressed == 1 then
-    params:set("note" .. edit+1, v)
+    if is_prev_16n_slider_v_crossing("note", slider_id, v) then
+      params:set("note" .. edit+1, v)
+      prev_16n_slider_v["note"][slider_id] = v
+    end
   end
   redraw()
 end

--- a/sines.lua
+++ b/sines.lua
@@ -10,7 +10,7 @@
 -- E1       - master volume
 -- E2      - active sine
 --
--- Active sine control:
+-- active sine control:
 -- E3      - amplitude
 -- K2 + E2 - note
 -- K2 + E3 - detune
@@ -20,7 +20,7 @@
 -- K1 + E2 - sample rate
 -- K1 + E3 - bit depth
 --
--- 16n sine control:
+-- sine control w/ 16n:
 --         - amplitude
 -- K2      - detune
 -- K3      - FM index

--- a/sines.lua
+++ b/sines.lua
@@ -63,32 +63,42 @@ local key_2_pressed = 0
 local key_3_pressed = 0
 local toggle = false
 local scale_toggle = false
-
-engine.name = "Sines"
-MusicUtil = require "musicutil"
-_16n = include "sines/lib/16n"
-
-function init()
-	print("loaded Sines engine")
-	add_params()
-	edit = 0
-	for i = 1,16 do
-		env_values[i] = params:get("env" .. i)
-		cents[i] = params:get("cents" .. i)
-		sliders[i] = (params:get("vol" .. i))*32
-	end
-
-        _16n.init(_16n_slider_callback)
-end
-
 local prev_16n_slider_v = {
   vol= {},
   cents= {},
   fm_index= {},
   smpl_rate= {},
   bit_depth= {},
-  node= {},
+  note= {},
 }
+
+engine.name = "Sines"
+MusicUtil = require "musicutil"
+_16n = include "sines/lib/16n"
+
+function init()
+  print("loaded Sines engine")
+  add_params()
+  edit = 0
+  for i = 1,16 do
+    env_values[i] = params:get("env" .. i)
+    cents[i] = params:get("cents" .. i)
+    sliders[i] = (params:get("vol" .. i))*32
+  end
+
+  _16n.init(_16n_slider_callback)
+  local cents_slider_v = util.linlin(-200, 200, 0, 127, 0)
+  local fm_slider_v = util.linlin(0.0, 200.0, 0, 127, 3.0)
+  local smpl_rate_slider_v = util.linlin(480, 48000, 0, 127, 48000)
+  local bit_depth_slider_v = util.linlin(1, 24, 0, 127, 24)
+  for i = 1,16 do
+    prev_16n_slider_v["cents"][i] = cents_slider_v
+    prev_16n_slider_v["fm_index"][i] = fm_slider_v
+    prev_16n_slider_v["smpl_rate"][i] = smpl_rate_slider_v
+    prev_16n_slider_v["bit_depth"][i] = bit_depth_slider_v
+    prev_16n_slider_v["note"][i] = notes[i]
+  end
+end
 
 function is_prev_16n_slider_v_crossing(mode, i, v)
   local prev_v = prev_16n_slider_v[mode][i]

--- a/sines.lua
+++ b/sines.lua
@@ -1,15 +1,32 @@
 --- ~ sines 0.8 ~
 -- @oootini, @eigen
--- E1 - norns master volume
--- E2 - select sine 1-16
--- E3 - set sine amplitude
--- K2 + E2 - change note
+--
+--   ~~    ~~    ~~    ~~    ~~    ~~
+--  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~
+-- ~    ~~    ~~    ~~    ~~    ~~    ~
+--
+-- ▼ instructions below ▼
+--
+-- E1       - master volume
+-- E2      - active sine
+--
+-- Active sine control:
+-- E3      - amplitude
+-- K2 + E2 - note
 -- K2 + E3 - detune
--- K2 + K3 - set voice panning
--- K3 + E2 - change envelope
--- K3 + E3 - change FM index
--- K1 + E2 - change sample rate
--- K1 + E3 - change bit depth
+-- K2 + K3 - voice panning
+-- K3 + E2 - envelope
+-- K3 + E3 - FM index
+-- K1 + E2 - sample rate
+-- K1 + E3 - bit depth
+--
+-- 16n sine control:
+--         - amplitude
+-- K2      - detune
+-- K3      - FM index
+-- K1 + K2 - sample rate
+-- K1 + K3 - bit depth
+-- K1 + K2 + K3 - note
 
 local sliders = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 local edit = 1

--- a/sines.lua
+++ b/sines.lua
@@ -1,5 +1,5 @@
 --- ~ sines 0.8 ~
--- @oootini
+-- @oootini, @eigen
 -- E1 - norns master volume
 -- E2 - select sine 1-16
 -- E3 - set sine amplitude


### PR DESCRIPTION
so, this PR adds auto-detection of 16n CC numbers (via sysex) at init and auto-binds it to control most bands parameters (in combination of key presses).

this makes sines way for playful as bunch of bands can be edited simultaneously.

there is also a new param to disable this feature, for people who prefer to bind their 16n to specific params via the global menu midi mapping.