### PR TITLE
Adding global "amp slew" setting

### DIFF
--- a/lib/16n.lua
+++ b/lib/16n.lua
@@ -88,7 +88,7 @@ local conf_16n=nil
 _16n.init = function(cc_cb_fn)
   for _,dev in pairs(midi.devices) do
     if dev.name~=nil and dev.name == "16n" then
-      print("detected 16n, will lookup its confif via sysex")
+      print("detected 16n, will lookup its config via sysex")
 
       dev_16n = dev
       midi_16n = midi.connect(dev.port)
@@ -137,7 +137,7 @@ end
 
 local function mustHaveConf()
   if conf_16n == nil then
-    error("Attempted to access 16n configuration while the later didn't get retrieved.")
+    error("Attempted to access the 16n configuration but it didn't get retrieved.")
   end
 end
 

--- a/lib/sines_engine.sc
+++ b/lib/sines_engine.sc
@@ -16,24 +16,24 @@ Engine_Sines : CroneEngine {
     var server = Crone.server;
     var def = SynthDef.new(\sin, {
       arg out, vol=0.0, hz=220, hz_lag=0.005,
-        env_bias=0.0, amp_atk=0.001, amp_rel=0.05,
+        env_bias=0.0, amp_atk=0.001, amp_rel=0.05, amp_slew=0.01,
         pan=0.0, pan_lag=0.005, mul=1, modPartial=1, carPartial=1, fm_index=1.0, sample_rate=48000, bit_depth=24;
-      var mod, car, car_decimate, amp_, hz_, pan_;
+      var mod, car, car_decimate, amp_, hz_, pan_, vol_;
       amp_ = EnvGen.ar(Env.circle([0, 1, 0], [amp_atk, amp_rel, 0.001]), levelBias: env_bias);
       hz_ = Lag.ar(K2A.ar(hz), hz_lag);
       pan_ = Lag.ar(K2A.ar(pan), pan_lag);
+      vol_ = Lag.ar(K2A.ar(vol), amp_slew);
       //could also try replacing with https://doc.sccode.org/Classes/PMOsc.html
       mod = SinOsc.ar(hz_ * modPartial, 0, hz_ * fm_index * LFNoise1.kr(5.reciprocal).abs);
       car = SinOsc.ar(hz_ * carPartial + mod, 0, mul);
       car_decimate = Decimator.ar(car, sample_rate, bit_depth, 1.0, 0);
-      Out.ar(out, Pan2.ar(car_decimate * amp_ * vol, pan_));
+      Out.ar(out, Pan2.ar(car_decimate * amp_ * vol_, pan_));
     });
     def.send(server);
     server.sync;
 
     synth = Array.fill(num, { Synth.new(\sin, [\out, context.out_b], target: context.xg) });
-
-    #[\hz, \vol, \env_bias, \pan, \amp_atk, \amp_rel, \hz_lag, \pan_lag, \fm_index].do({
+    #[\hz, \vol, \env_bias, \pan, \amp_atk, \amp_rel, \amp_slew, \hz_lag, \pan_lag, \fm_index].do({
       arg name;
       this.addCommand(name, "if", {
         arg msg;

--- a/sines.lua
+++ b/sines.lua
@@ -1,4 +1,4 @@
---- ~ sines 0.9 ~
+--- ~ sines 0.91 ~
 -- @oootini, @eigen
 --
 --   ~~    ~~    ~~    ~~    ~~    ~~
@@ -193,6 +193,9 @@ function init()
         min = 0, max = 127, default = 60, formatter = function(param) return MusicUtil.note_num_to_name(param:get(), true) end, action = function() set_notes() end}
         params:add{type = "option", id = "16n_auto", name = "auto bind 16n", options = {"yes", "no"}, default = 1}
         params:add{type = "option", id = "16n_params_jump", name = "16n params jumps", options = {"yes", "no"}, default = 1}
+        --amp slew
+        params:add_control("amp_slew", "amp slew", controlspec.new(0.01, 10, 'lin', 0.01, 0.01))
+        params:set_action("amp_slew", function(x) set_amp_slew(x) end)
         --set virtual faders params
         params:add_group("virtual faders", 16)
         for i = 1, 16 do
@@ -239,6 +242,13 @@ function init()
         scale_toggle = true
         for i = 1, 16 do
             params:set("note" .. i, notes[i])
+        end
+    end
+
+    function set_amp_slew(slew_rate)
+        -- set the slew rate for every voice 
+        for i = 1, 16 do
+            engine.amp_slew(i, slew_rate)
         end
     end
 


### PR DESCRIPTION
Added a new global param **amp slew** which can be used to set how quickly the voices follows the midi cc slider value. 

**amp slew** can be set from 0.01 to 10 seconds.  