### PR TITLE
MIDI CC's 0-15 change sines volume

### DIFF
--- a/sines.lua
+++ b/sines.lua
@@ -399,6 +399,11 @@ m.event = function(data)
   -- if sliders[i] < 0 then sliders[i] = 0 end
   -- end
   -- end
+  local faderNum = d.cc + 1
+  if faderNum < 17 then
+    sliders[faderNum] = d.val
+    params:set("vol" .. faderNum, d.val)
+  end
   --allow root note to be set from midi keyboard - doesn't work with multiple midi devices?
   if d.type == "note_on" then
     params:set("root_note", d.note)


### PR DESCRIPTION
I could not figure out how to use MIDI CCs on my midi controller (not a 16n) to control the volumes on the sines.
This PR allows it. CC 0 controls sine 1, CC 1 controls sine 2, and so on up to CC 15. 

I guess there are more CCs that are supposed to control other parameters (based on the TouchOsc template linked in the description of this [video](https://youtu.be/DRsg1u0DaNE?t=236)) but I didn't mess with those....
