### PR TITLE
Momentary behaviour for grid fader presses

### DIFF
--- a/sines.lua
+++ b/sines.lua
@@ -37,6 +37,10 @@ local fader_abs_vals = {}
 local follow_clocks = {}
 local crow_out_pairs = {}
 
+-- switch between toggle and momentary behaviour for grid "faders"
+local mom_toggle = false
+-- hold previous values in momentary grid faders mode
+local last_vols = {}
 
 for i = 1, 16 do
   fader_follow_vals[i] = 0
@@ -843,9 +847,13 @@ function key(n, z)
       -- env follower
       params:set("play_mode", 0)
     end
+  -- switch toggle and momentary for grid faders, momentary while K1 is held
+  elseif n == 1 then
+    mom_toggle = z
   end
   screen_dirty = true
 end
+
 
 function redraw()
   redraw_screen()
@@ -972,9 +980,17 @@ end
 
 g.key = function(x,y,z)
   if z == 1 then
+    -- save previous value 
+    last_vols[x] = params:get("vol" .. x)
     local amp_value = util.linlin(0, grid_height, 0.0, 1.0, grid_height - y)
     params:set("vol" .. x, amp_value)
     edit = x - 1
+  else
+    -- in momentary mode when grid fader button is released go back to previous value
+    if mom_toggle == 1 then
+      params:set("vol" .. x, last_vols[x]) 
+    end  
+    edit = x -1
   end
   screen_dirty = true
 end

--- a/sines.lua
+++ b/sines.lua
@@ -37,10 +37,6 @@ local fader_abs_vals = {}
 local follow_clocks = {}
 local crow_out_pairs = {}
 
--- switch between toggle and momentary behaviour for grid "faders"
-local mom_toggle = false
--- hold previous values in momentary grid faders mode
-local last_vols = {}
 
 for i = 1, 16 do
   fader_follow_vals[i] = 0
@@ -847,13 +843,9 @@ function key(n, z)
       -- env follower
       params:set("play_mode", 0)
     end
-  -- switch toggle and momentary for grid faders, momentary while K1 is held
-  elseif n == 1 then
-    mom_toggle = z
   end
   screen_dirty = true
 end
-
 
 function redraw()
   redraw_screen()
@@ -980,17 +972,9 @@ end
 
 g.key = function(x,y,z)
   if z == 1 then
-    -- save previous value 
-    last_vols[x] = params:get("vol" .. x)
     local amp_value = util.linlin(0, grid_height, 0.0, 1.0, grid_height - y)
     params:set("vol" .. x, amp_value)
     edit = x - 1
-  else
-    -- in momentary mode when grid fader button is released go back to previous value
-    if mom_toggle == 1 then
-      params:set("vol" .. x, last_vols[x]) 
-    end  
-    edit = x -1
   end
   screen_dirty = true
 end

--- a/sines.lua
+++ b/sines.lua
@@ -12,6 +12,7 @@
 -- E3 - selected sine volume
 -- K2 - toggle sines/ctrl
 -- K3 - toggle env/follow
+-- K1 - toggle/momentary for grid faders
 --
 -- 16n control
 -- n - sine volume

--- a/sines.lua
+++ b/sines.lua
@@ -12,13 +12,15 @@
 -- E3 - selected sine volume
 -- K2 - toggle sines/ctrl
 -- K3 - toggle env/follow
--- K1 - toggle/momentary for grid faders
+-- K1 - hold for momentary grid faders behaviour
 --
 -- 16n control
 -- n - sine volume
 --
 -- z_tuning
 -- params > edit > Z_TUNING
+
+
 
 engine.name = "Sines"
 _mods = require 'core/mods'
@@ -38,6 +40,10 @@ local fader_abs_vals = {}
 local follow_clocks = {}
 local crow_out_pairs = {}
 
+-- switch between toggle and momentary behaviour for grid "faders"
+local mom_toggle = false
+-- hold previous values in momentary grid faders mode
+local last_vols = {}
 
 for i = 1, 16 do
   fader_follow_vals[i] = 0
@@ -844,9 +850,13 @@ function key(n, z)
       -- env follower
       params:set("play_mode", 0)
     end
+  -- switch toggle and momentary for grid faders, momentary while K1 is held
+  elseif n == 1 then
+    mom_toggle = z
   end
   screen_dirty = true
 end
+
 
 function redraw()
   redraw_screen()
@@ -973,9 +983,17 @@ end
 
 g.key = function(x,y,z)
   if z == 1 then
+    -- save previous value 
+    last_vols[x] = params:get("vol" .. x)
     local amp_value = util.linlin(0, grid_height, 0.0, 1.0, grid_height - y)
     params:set("vol" .. x, amp_value)
     edit = x - 1
+  else
+    -- in momentary mode when grid fader button is released go back to previous value
+    if mom_toggle == 1 then
+      params:set("vol" .. x, last_vols[x]) 
+    end  
+    edit = x -1
   end
   screen_dirty = true
 end


### PR DESCRIPTION
added functionality so that that grid button presses only play the notes as long as the button is pressed and return to previous values once the button is released. this works as long as K1 is held. 
see also https://llllllll.co/t/sines/39292/498

it doesn't seem to break other functionality and if it doesn't clash with any other plans you have for K1 maybe you'd like to integrate it. 